### PR TITLE
Autocast bfloat16 to float32 for llama on clang

### DIFF
--- a/exo/inference/tinygrad/models/llama.py
+++ b/exo/inference/tinygrad/models/llama.py
@@ -274,9 +274,12 @@ def convert_from_huggingface(weights: Dict[str, Tensor], model: Transformer, n_h
   return sd
 
 
-def fix_bf16(weights: Dict[Any, Tensor]):
-  if getenv("SUPPORT_BF16", 1):
+def fix_bf16(weights:Dict[Any, Tensor]):
+  if Device.DEFAULT == "CLANG":
     # TODO: without casting to float16, 70B llama OOM on tinybox.
-    return {k: v.cast(dtypes.float16) if v.dtype == dtypes.bfloat16 else v for k, v in weights.items()}
+    return {
+      k: (v.llvm_bf16_cast(dtypes.float32).to(v.device) if v.dtype == dtypes.bfloat16 else v)
+      for k, v in weights.items()
+    }
   # TODO: check if device supports bf16
-  return {k: v.llvm_bf16_cast(dtypes.half).to(v.device) if v.dtype == dtypes.bfloat16 else v for k, v in weights.items()}
+  return {k:v.cast(dtypes.float16) if v.dtype == dtypes.bfloat16 else v for k,v in weights.items()}


### PR DESCRIPTION
The content of this merge request is as follows:

- Not all CPUs support the bfloat16 format, so autocast bfloat16 to float32 for llama on clang.